### PR TITLE
Several modifications to how the computations are done + shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,13 @@ nav {
 The size of the font will not be increased if the element with `resize-text` class will not be able to increase its width in dependency to the parent's width. This is not built into the addon as this depends on the context in which the addon is used.
 
 ### Parameters
-|Paramter|type|description
-|-|-|-|
-|**minSize**| number | minimum font size in px |
-|**maxSize**| number | maximum font size in px |
-|**containerElement**| element | The containerElement parameter allows to specify an optional dom element whichs `clientWidth` property will be used to determine the available space. This is particularly useful when the dom element that should be resized is not a block element. For instance the text of a link should be resized, but should not occupy the full width unless needed.
+|Paramter|type|default value|description
+|-|-|-|-|
+|**minSize**| number | 2 | minimum font size in px |
+|**maxSize**| number | 80 | maximum font size in px |
+|**containerElement**| element | `this.element` | The containerElement parameter allows to specify an optional dom element whichs `clientWidth` property will be used to determine the available space. This is particularly useful when the dom element that should be resized is not a block element. For instance the text of a link should be resized, but should not occupy the full width unless needed.|
+|**shrink**| boolean | true | (Optional) set to `false` if you only want to grow the text (never shrink it).|
+|**grow**| boolean | true | (Optional) set to `false` if you only want to shrink the text (never grow it).|
 
 ## Contribute
 

--- a/addon/mixins/resize-text.js
+++ b/addon/mixins/resize-text.js
@@ -13,17 +13,8 @@ export default Mixin.create({
   minSize: 2,
   maxSize: 80,
 
-  // NOTE: shrink and grow are shortcuts (as mentioned below)
-  // the reasoning: often times the template developer does not have access to (or does not know)
-  // the specified font size (in pixels)
-  // obviously that can be computed by you, the developer, but these shortcuts handle it for you
-
-  // passed-in: set to false if you only want to grow the text (never shrink)
-  // setting to false is an alternative to setting maxSize to your current font size
+  // NOTE: shrink and grow are shortcuts - see the README for usage/details
   shrink: true,
-
-  // passed-in: set to false if you only want to shrink the text (never grow)
-  // setting to false is an alternative to setting minSize to your current font size
   grow: true,
 
   textMeasurer: service(),
@@ -45,10 +36,16 @@ export default Mixin.create({
     const style = getComputedStyle(container);
     const currentFontSize = extractPixels(style.fontSize);
 
-    // if shrink or grow are set to false, use the currentFontSize
-    const { shrink, grow } = this.getProperties('shrink', 'grow');
-    const minSize = !shrink ? currentFontSize : this.get('minSize');
-    const maxSize = !grow ? currentFontSize : this.get('maxSize');
+    // if shrink or grow are set to false, use the originalFontSize
+    const { shrink, grow} = this.getProperties('shrink', 'grow');
+    let originalFontSize = this.originalFontSize;
+    if (!originalFontSize){
+      originalFontSize = currentFontSize;
+      this.set('originalFontSize', currentFontSize);
+    }
+
+    const minSize = !shrink ? originalFontSize : this.get('minSize');
+    const maxSize = !grow ? originalFontSize : this.get('maxSize');
 
     // the computed style.width is the given width, w/o padding, which is what we want
     let elementWidth = extractPixels(style.width) || container.clientWidth;
@@ -58,7 +55,7 @@ export default Mixin.create({
 
     let fontSize = this.get('textMeasurer')
         .fitTextSize(this.element.innerText, elementWidth,
-          `${style.fontStyle} ${style.fontSize} ${style.fontFamily}`);
+          `${style.fontStyle} 14px ${style.fontFamily}`);
     if (fontSize > maxSize) {
       fontSize = maxSize;
     } else if (fontSize < minSize) {

--- a/addon/mixins/resize-text.js
+++ b/addon/mixins/resize-text.js
@@ -1,12 +1,30 @@
 import Mixin from '@ember/object/mixin';
 import { inject as service } from '@ember/service';
 
+const extractPixels = function(value) {
+  let match = /(\d+)px/i.exec(value || '');
+  return match ? parseInt(match[1], 10) : 0;
+};
+
 export default Mixin.create({
 
   classNames: ['resize-text'],
 
   minSize: 2,
   maxSize: 80,
+
+  // NOTE: shrink and grow are shortcuts (as mentioned below)
+  // the reasoning: often times the template developer does not have access to (or does not know)
+  // the specified font size (in pixels)
+  // obviously that can be computed by you, the developer, but these shortcuts handle it for you
+
+  // passed-in: set to false if you only want to grow the text (never shrink)
+  // setting to false is an alternative to setting maxSize to your current font size
+  shrink: true,
+
+  // passed-in: set to false if you only want to shrink the text (never grow)
+  // setting to false is an alternative to setting minSize to your current font size
+  grow: true,
 
   textMeasurer: service(),
 
@@ -23,24 +41,34 @@ export default Mixin.create({
   },
 
   scaleFont() {
-    const style = getComputedStyle(this.element);
-    const minSize = this.get('minSize');
-    const maxSize = this.get('maxSize');
-    const container = this.get('containerElement');
-    let elementWidth;
-    if (container) {
-      elementWidth = container.clientWidth;
-    } else {
-      elementWidth = this.element.clientWidth;
-    }
+    const container = this.get('containerElement') || this.element;
+    const style = getComputedStyle(container);
+    const currentFontSize = extractPixels(style.fontSize);
+
+    // if shrink or grow are set to false, use the currentFontSize
+    const { shrink, grow } = this.getProperties('shrink', 'grow');
+    const minSize = !shrink ? currentFontSize : this.get('minSize');
+    const maxSize = !grow ? currentFontSize : this.get('maxSize');
+
+    // the computed style.width is the given width, w/o padding, which is what we want
+    let elementWidth = extractPixels(style.width) || container.clientWidth;
+    // remove the padding, which is the actual inner/renderable width
+    elementWidth -= extractPixels(style.paddingLeft);
+    elementWidth -= extractPixels(style.paddingRight);
+
     let fontSize = this.get('textMeasurer')
-        .fitTextSize(this.element.innerText, elementWidth, style.fontStyle + ' 14px ' + style.fontFamily);
+        .fitTextSize(this.element.innerText, elementWidth,
+          `${style.fontStyle} ${style.fontSize} ${style.fontFamily}`);
     if (fontSize > maxSize) {
       fontSize = maxSize;
     } else if (fontSize < minSize) {
       fontSize = minSize;
     }
-    this.element.style['font-size'] = fontSize + 'px';
+
+    // only set the style if it actually changed
+    if (fontSize !== currentFontSize) {
+        this.element.style['font-size'] = fontSize + 'px';
+    }
   },
 
   didUpdate() {

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -2,3 +2,11 @@
   width: 100%;
   background: #E46651;
 }
+
+.text-lg {
+  font-size: 20px;
+}
+
+.text-xl {
+  font-size: 40px;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -13,3 +13,23 @@
   Specifying a parent container, which is used to track the available width allows to render inline dom elements, while removing the requirement to occupy all the available width. This is particularly useful to display links that should resize, but not occupy the full width unless needed.
 </p>
 {{resizing-component}}
+
+<h2>only grow - never shrink</h2>
+<pre>\{{#resize-text shrink=false classNames="text-lg"}}
+  This will grow, but not shrink below the original font size.
+\{{/resize-text}}
+</pre>
+<p>If you specify that you don't want the text to ever shrink below the original font size, it can still grow to take up the available width of the container. Just be careful, because since it won't shrink, your text can get cut-off at smaller widths.</p>
+{{#resize-text shrink=false classNames="text-lg"}}
+  This text will only grow, and won't shrink smaller than the css font-size property (20px).
+{{/resize-text}}
+
+<h2>only shrink - never grow</h2>
+<pre>\{{#resize-text grow=false classNames="text-xl"}}
+  This will shrink, but not grow above the original font size.
+\{{/resize-text}}
+</pre>
+<p>If you specify that you don't want the text to ever grow below the original font size, it can still shrink as the width of the container becomes smaller.</p>
+{{#resize-text grow=false classNames="text-xl"}}
+  This text will only shrink - it will use the size of the css font-size property as the max (40px).
+{{/resize-text}}

--- a/tests/integration/components/resize-text-test.js
+++ b/tests/integration/components/resize-text-test.js
@@ -71,4 +71,67 @@ module('Integration | Component | resize text', function(hooks) {
     assert.dom('.resize-text').hasText('template block text');
     assert.equal(getComputedStyle(find('.resize-text'))['font-size'], '20px');
   });
+
+  test('do not grow if we are told not to', async function(assert) {
+
+    // in some situations you may want to only shrink the text if it can't fit in the container
+
+    getRootElement().getElementsByClassName('ember-view')[0].style.width = '800px';
+    getRootElement().style.fontSize = '10px';
+
+    await render(hbs`
+      {{#resize-text grow=false}}
+        template block text
+      {{/resize-text}}
+    `);
+
+    assert.dom('.resize-text').hasText('template block text');
+    assert.equal(getComputedStyle(find('.resize-text'))['font-size'], '10px');
+  });
+
+  test('do not shrink if we are told not to', async function(assert) {
+
+    getRootElement().getElementsByClassName('ember-view')[0].style.width = '100px';
+    getRootElement().style.fontSize = '20px';
+
+    await render(hbs`
+      {{#resize-text shrink=false}}
+        template block text
+      {{/resize-text}}
+    `);
+
+    assert.dom('.resize-text').hasText('template block text');
+    assert.equal(getComputedStyle(find('.resize-text'))['font-size'], '20px');
+  });
+
+  test('resize with padding taken into account', async function(assert) {
+
+    // first compute without padding
+    let container = getRootElement();
+    container.style.width = '100px';
+    container.style['font-size'] = '10px';
+    this.set('containerElement', container);
+    await render(hbs`
+      {{#resize-text containerElement=containerElement}}
+        template block text
+      {{/resize-text}}
+    `);
+    assert.dom('.resize-text').hasText('template block text');
+    assert.equal(getComputedStyle(find('.resize-text'))['font-size'], '13px');
+
+    // now, adding padding - we increase the width of the container, but add padding
+    container = getRootElement();
+    container.style.width = '140px';
+    container.style['font-size'] = '10px';
+    container.style.paddingLeft = '20px';
+    container.style.paddingRight = '20px';
+    this.set('containerElement', container);
+    await render(hbs`
+      {{#resize-text containerElement=containerElement}}
+        template block text
+      {{/resize-text}}
+    `);
+    assert.dom('.resize-text').hasText('template block text');
+    assert.equal(getComputedStyle(find('.resize-text'))['font-size'], '13px');
+  });
 });


### PR DESCRIPTION
- use the computed style width, which is the actual inner width
- subract padding
- only set the element font-size iff it changed
- add shrink/grow shortcuts for not having to know min/max pixels
- pass the current font size to the textMeasurer
- use the container style properties

Let me know what you think!

Thanks!